### PR TITLE
[FIX] - Supression d'une session par profileId dans ModelPlageSession

### DIFF
--- a/back/model/ModelPlageSession.js
+++ b/back/model/ModelPlageSession.js
@@ -87,6 +87,7 @@ class ModelPlageSession extends Model {
       return true;
     } catch (err) {
       debug("remove PlageSession : " + err.stack);
+      return false;
     }
   }
 


### PR DESCRIPTION
**Issue** 
Erreur non traitée lors de la suppression d'une session par profileId dans ModelPlageSession #8 

**Modification** - _(ligne 90)_
Ajout de "return false;" dans la méthode `deleteByProfileId` du fichier `ModelPlageSession.js`, pour une gestion correcte de l'erreur.
