### PR TITLE
Ajout de la vérification des champs obligatoires dans create

### DIFF
--- a/back/controller/ControllerProfileAPI.js
+++ b/back/controller/ControllerProfileAPI.js
@@ -9,6 +9,15 @@ module.exports.create = async function (req, res) {
   if (!req.body) {
     //Invalid request
     res.status(400).end();
+    return;
+  }
+
+  // Check required fields
+  if (!req.body.job || !req.body.sector) {
+    return res.status(400).json({
+      error: "Bad Request",
+      message: "Les champs 'job' et 'sector' sont obligatoires."
+    });
   }
 
   const data = {


### PR DESCRIPTION
Ce pull request ajoute une validation des champs obligatoires dans la méthode `create` de `ControllerProfileAPI.js`. Les changements effectués incluent :

1. **Vérification des champs `job` et `sector` :**
   - Si ces champs ne sont pas fournis dans le corps de la requête (`req.body`), une réponse avec un statut `400 Bad Request` est retournée.
   - Un message d'erreur détaillé est envoyé pour informer l'utilisateur : `"Les champs 'job' et 'sector' sont obligatoires."`

2. **Code ajouté :**
   ```javascript
   if (!req.body.job || !req.body.sector) {
       return res.status(400).json({
           error: "Bad Request",
           message: "Les champs 'job' et 'sector' sont obligatoires."
       });
   }
   ```

**Motivation :**
- Cette modification garantit une meilleure gestion des erreurs en validant les données reçues avant de les traiter.
- Cela évite de créer des profils incomplets ou non conformes.

**Impact :**
- Aucune modification n'a été apportée aux autres parties du code.
- Cette mise à jour affecte uniquement la méthode `create`.